### PR TITLE
feat(home): redesign hero card and category grid

### DIFF
--- a/components/home/CategoryGrid.tsx
+++ b/components/home/CategoryGrid.tsx
@@ -5,37 +5,41 @@ import {
 } from "lucide-react";
 
 const CATEGORIES = [
-  { href: "/directory?category=hospital",   icon: Stethoscope,     label: "병원·치과",  bg: "#FFF0EE", color: "#E8321C" },
-  { href: "/directory?category=lawyer",     icon: Scale,           label: "변호사",     bg: "#EEF2FF", color: "#4F46E5" },
-  { href: "/directory?category=accountant", icon: Calculator,      label: "회계사",     bg: "#FFFBEE", color: "#D97706" },
-  { href: "/directory?category=restaurant", icon: UtensilsCrossed, label: "식당·카페",  bg: "#EDFDF5", color: "#059669" },
-  { href: "/directory?category=beauty",     icon: Scissors,        label: "뷰티·미용",  bg: "#FDF2F8", color: "#DB2777" },
-  { href: "/directory?category=realestate", icon: Home,            label: "부동산",     bg: "#F5F3FF", color: "#7C3AED" },
-  { href: "/directory?category=education",  icon: BookOpen,        label: "학원·교육",  bg: "#ECFEFF", color: "#0891B2" },
-  { href: "/directory?category=jobs",       icon: Briefcase,       label: "채용·구인",  bg: "#FFF7ED", color: "#EA580C" },
+  { href: "/directory?category=hospital",   icon: Stethoscope,     label: "병원·치과",  bg: "#FFF0EE", color: "#E8321C", hover: "#FFE4E0" },
+  { href: "/directory?category=lawyer",     icon: Scale,           label: "변호사",     bg: "#EEF2FF", color: "#4F46E5", hover: "#E0E7FF" },
+  { href: "/directory?category=accountant", icon: Calculator,      label: "회계사",     bg: "#FFFBEE", color: "#D97706", hover: "#FEF3C7" },
+  { href: "/directory?category=restaurant", icon: UtensilsCrossed, label: "식당·카페",  bg: "#EDFDF5", color: "#059669", hover: "#D1FAE5" },
+  { href: "/directory?category=beauty",     icon: Scissors,        label: "뷰티·미용",  bg: "#FDF2F8", color: "#DB2777", hover: "#FCE7F3" },
+  { href: "/directory?category=realestate", icon: Home,            label: "부동산",     bg: "#F5F3FF", color: "#7C3AED", hover: "#EDE9FE" },
+  { href: "/directory?category=education",  icon: BookOpen,        label: "학원·교육",  bg: "#ECFEFF", color: "#0891B2", hover: "#CFFAFE" },
+  { href: "/directory?category=jobs",       icon: Briefcase,       label: "채용·구인",  bg: "#FFF7ED", color: "#EA580C", hover: "#FFEDD5" },
 ];
 
 export function CategoryGrid() {
   return (
-    <div className="flex gap-2 overflow-x-auto scrollbar-hide py-0.5">
+    <div className="flex gap-2.5 overflow-x-auto scrollbar-hide py-0.5">
       {CATEGORIES.map((cat) => {
         const Icon = cat.icon;
         return (
           <Link
             key={cat.href}
             href={cat.href}
-            className="flex-shrink-0 flex items-center gap-2 px-4 py-2 rounded-full
-                       border border-gray-200 bg-white text-gray-700 text-sm font-medium
-                       hover:border-[#FF5C5C] hover:text-[#FF5C5C] hover:bg-[#FFF8F8]
-                       transition-all duration-150"
+            className="group flex-shrink-0 flex items-center gap-2.5 pl-1.5 pr-4 py-1.5
+                       rounded-full border border-transparent
+                       bg-white shadow-sm hover:shadow-md
+                       text-gray-700 text-sm font-semibold
+                       transition-all duration-200 hover:scale-[1.03] active:scale-95"
+            style={{ "--hover-bg": cat.hover } as React.CSSProperties}
           >
             <span
-              className="w-5 h-5 rounded-full flex items-center justify-center flex-shrink-0"
+              className="w-7 h-7 rounded-full flex items-center justify-center flex-shrink-0 transition-colors duration-200"
               style={{ backgroundColor: cat.bg }}
             >
-              <Icon className="w-3 h-3" style={{ color: cat.color }} strokeWidth={2.2} />
+              <Icon className="w-3.5 h-3.5 transition-colors duration-200" style={{ color: cat.color }} strokeWidth={2.2} />
             </span>
-            {cat.label}
+            <span className="transition-colors duration-200" style={{ color: "inherit" }}>
+              {cat.label}
+            </span>
           </Link>
         );
       })}

--- a/components/home/HeroCard.tsx
+++ b/components/home/HeroCard.tsx
@@ -1,47 +1,109 @@
 import Link from "next/link";
 import { PenLine, Search } from "lucide-react";
-import { HERO_COPY, TAGLINE } from "@/lib/copy";
+import { HERO_COPY } from "@/lib/copy";
+
+const STATS = [
+  { n: "2,400+", label: "한인 회원", icon: "👥" },
+  { n: "580+",   label: "등록 비즈니스", icon: "🏢" },
+  { n: "8개",    label: "서비스 지역", icon: "📍" },
+];
 
 export function HeroCard() {
   return (
-    <div
-      className="relative rounded-3xl overflow-hidden px-6 py-7 lg:px-10 lg:py-10
-                    bg-gradient-to-br from-[#FFF8F8] via-white to-[#F8F4FF]
-                    border border-gray-100"
-    >
-      {/* Decorative blobs */}
-      <div className="absolute -top-16 -right-16 w-56 h-56 bg-[#FF5C5C]/8 rounded-full blur-3xl pointer-events-none" />
-      <div className="absolute -bottom-10 left-1/3 w-40 h-40 bg-purple-400/5 rounded-full blur-2xl pointer-events-none" />
+    <div className="relative rounded-3xl overflow-hidden px-6 py-8 lg:px-12 lg:py-12 hero-gradient">
+      {/* Noise grain texture overlay for depth */}
+      <div
+        aria-hidden="true"
+        className="absolute inset-0 pointer-events-none opacity-[0.035]"
+        style={{
+          backgroundImage: `url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='300' height='300'%3E%3Cfilter id='n'%3E%3CfeTurbulence type='fractalNoise' baseFrequency='0.75' numOctaves='4' stitchTiles='stitch'/%3E%3C/filter%3E%3Crect width='300' height='300' filter='url(%23n)'/%3E%3C/svg%3E")`,
+          backgroundSize: "300px 300px",
+        }}
+      />
 
-      <div className="relative z-10 lg:flex lg:items-center lg:justify-between lg:gap-10">
-        {/* Text + CTAs */}
-        <div>
+      {/* Giant watermark "소리" — brand identity anchor */}
+      <div
+        aria-hidden="true"
+        className="absolute -right-6 -top-6 font-black text-white select-none pointer-events-none leading-none"
+        style={{
+          fontSize: "clamp(110px, 18vw, 260px)",
+          opacity: 0.04,
+          fontFamily: "'Pretendard', sans-serif",
+          letterSpacing: "-0.02em",
+        }}
+      >
+        소리
+      </div>
+
+      {/* Coral glow accents */}
+      <div aria-hidden="true" className="absolute top-0 left-0 w-72 h-72 bg-[#FF5C5C]/10 rounded-full blur-3xl pointer-events-none" />
+      <div aria-hidden="true" className="absolute bottom-0 right-1/4 w-48 h-48 bg-[#FF5C5C]/6 rounded-full blur-2xl pointer-events-none" />
+
+      {/* Content */}
+      <div className="relative z-10 lg:flex lg:items-center lg:justify-between lg:gap-12">
+
+        {/* Left — headline + CTAs */}
+        <div className="max-w-md animate-fade-in-up">
+          {/* Badge */}
           <div
-            className="inline-flex items-center gap-2 bg-[#FF5C5C]/10 text-[#FF5C5C]
-                          text-xs font-semibold px-3 py-1.5 rounded-full mb-4"
+            className="inline-flex items-center gap-2 text-xs font-semibold px-3 py-1.5 rounded-full mb-5"
+            style={{
+              background: "rgba(255, 92, 92, 0.15)",
+              color: "#FF9090",
+              border: "1px solid rgba(255, 92, 92, 0.3)",
+            }}
           >
             <span className="w-1.5 h-1.5 rounded-full bg-[#FF5C5C] animate-pulse" />
             {HERO_COPY.badge}
           </div>
-          <h1 className="text-2xl lg:text-3xl font-bold text-gray-900 leading-tight tracking-tight">
+
+          {/* Headline */}
+          <h1 className="text-3xl lg:text-[2.6rem] font-black text-white leading-[1.15] tracking-tight">
             {HERO_COPY.headline[0]}
             <br />
-            {HERO_COPY.headline[1]} <span className="text-[#FF5C5C]">{HERO_COPY.headlineBrand}</span>
+            {HERO_COPY.headline[1]}{" "}
+            <span className="relative inline-block text-[#FF5C5C]">
+              {HERO_COPY.headlineBrand}
+              {/* hand-drawn underline stroke */}
+              <svg
+                aria-hidden="true"
+                className="absolute -bottom-1 left-0 w-full overflow-visible"
+                height="6"
+                viewBox="0 0 40 6"
+                fill="none"
+                xmlns="http://www.w3.org/2000/svg"
+                preserveAspectRatio="none"
+              >
+                <path
+                  d="M1 4.5 Q10 1.5 20 3.5 Q30 5.5 39 2.5"
+                  stroke="#FF5C5C"
+                  strokeWidth="2.5"
+                  strokeLinecap="round"
+                  opacity="0.65"
+                />
+              </svg>
+            </span>
           </h1>
-          <p className="text-gray-500 text-sm mt-2.5 leading-relaxed">
+
+          <p className="text-white/50 text-sm mt-4 leading-relaxed max-w-xs">
             {HERO_COPY.sub}
           </p>
-          <div className="flex flex-wrap gap-2.5 mt-5">
+
+          {/* CTAs */}
+          <div className="flex flex-wrap gap-3 mt-7">
             <Link
               href="/community/new"
-              className="inline-flex items-center gap-2 btn-coral text-sm"
+              className="inline-flex items-center gap-2 btn-coral text-sm shadow-lg shadow-[#FF5C5C]/20"
             >
               <PenLine className="w-4 h-4" />
               글쓰기
             </Link>
             <Link
               href="/directory"
-              className="inline-flex items-center gap-2 btn-outline text-sm"
+              className="inline-flex items-center gap-2 text-sm font-semibold
+                         text-white/70 hover:text-white
+                         border border-white/20 hover:border-white/40
+                         px-5 py-2.5 rounded-xl transition-all duration-150 active:scale-95"
             >
               <Search className="w-4 h-4" />
               비즈니스 찾기
@@ -49,22 +111,37 @@ export function HeroCard() {
           </div>
         </div>
 
-        {/* Stats — desktop only */}
-        <div className="hidden lg:flex items-center gap-8 shrink-0">
-          {[
-            { n: "2,400+", label: "한인 회원" },
-            { n: "580+", label: "등록 비즈니스" },
-            { n: "8개", label: "서비스 지역" },
-          ].map((stat, i, arr) => (
-            <div key={stat.label} className="flex items-center gap-8">
-              <div className="text-center">
-                <div className="text-xl font-bold text-gray-900">{stat.n}</div>
-                <div className="text-xs text-gray-500 mt-0.5">{stat.label}</div>
-              </div>
-              {i < arr.length - 1 && <div className="w-px h-10 bg-gray-200" />}
+        {/* Right — stat grid (desktop only) */}
+        <div
+          className="hidden lg:grid grid-cols-3 shrink-0 divide-x divide-white/10
+                     border border-white/10 rounded-2xl overflow-hidden stagger-2 animate-fade-in-up"
+        >
+          {STATS.map((stat) => (
+            <div
+              key={stat.label}
+              className="flex flex-col items-center justify-center gap-2 px-8 py-7 text-center
+                         bg-white/[0.04] hover:bg-white/[0.07] transition-colors duration-200"
+            >
+              <span className="text-2xl leading-none">{stat.icon}</span>
+              <span className="text-2xl font-black text-white leading-none tracking-tight">
+                {stat.n}
+              </span>
+              <span className="text-[11px] text-white/40 font-medium leading-snug">
+                {stat.label}
+              </span>
             </div>
           ))}
         </div>
+      </div>
+
+      {/* Mobile stat strip */}
+      <div className="lg:hidden relative z-10 flex items-center gap-0 mt-7 pt-6 border-t border-white/10 divide-x divide-white/10">
+        {STATS.map((stat) => (
+          <div key={stat.label} className="flex-1 text-center px-2">
+            <div className="text-base font-black text-white leading-none">{stat.n}</div>
+            <div className="text-[10px] text-white/40 mt-1 font-medium">{stat.label}</div>
+          </div>
+        ))}
       </div>
     </div>
   );


### PR DESCRIPTION
- Replace light gradient hero with dark navy (hero-gradient) background
- Add oversized 소리 watermark text as visual brand anchor
- Add SVG noise grain texture overlay for depth
- Add coral glow blob accents on dark background
- Add hand-drawn SVG underline on brand name in headline
- Replace side-by-side stats with frosted glass stat grid (desktop)
- Add mobile stat strip below CTAs (was hidden on mobile before)
- Add coral drop shadow on primary CTA button
- Elevate CategoryGrid pills: larger icon swatch, shadow-sm/md, scale hover