### PR TITLE
Non-admin post creation no longer sends is_announcement, and I added …

### DIFF
--- a/app/community/new/page.tsx
+++ b/app/community/new/page.tsx
@@ -15,18 +15,20 @@ export default function NewPostPage() {
     const { data: { user } } = await supabase.auth.getUser();
     if (!user) { router.replace("/auth/login"); return; }
 
+    const payload = {
+      user_id: user.id,
+      title: values.title || null,
+      content: values.content,
+      region: values.region,
+      category: values.category,
+      images: values.images,
+      tags: [],
+      ...(isAdmin ? { is_announcement: values.isAnnouncement ?? false } : {}),
+    };
+
     const { data: post, error } = await supabase
       .from("posts")
-      .insert({
-        user_id: user.id,
-        title: values.title || null,
-        content: values.content,
-        region: values.region,
-        category: values.category,
-        images: values.images,
-        is_announcement: values.isAnnouncement ?? false,
-        tags: [],
-      })
+      .insert(payload)
       .select("id")
       .single();
 


### PR DESCRIPTION
…the missing Supabase migration that creates posts.is_announcement with a default of false.