### PR TITLE
fix: improve local auth flow and post recency labels

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,4 +1,5 @@
 NEXT_PUBLIC_SUPABASE_URL=https://your-project.supabase.co
 NEXT_PUBLIC_SUPABASE_ANON_KEY=your-anon-key-here
 SUPABASE_SERVICE_ROLE_KEY=your-service-role-key-here
+# Canonical public site URL for metadata/sitemap. Auth callbacks use the current app origin.
 NEXT_PUBLIC_APP_URL=http://localhost:3000

--- a/app/auth/callback/route.ts
+++ b/app/auth/callback/route.ts
@@ -5,8 +5,9 @@ import type { EmailOtpType } from "@supabase/supabase-js";
 
 export async function GET(request: NextRequest) {
   const { searchParams } = new URL(request.url);
-  // Use APP_URL env var to avoid 127.0.0.1 vs localhost mismatch in local dev
-  const origin = process.env.NEXT_PUBLIC_APP_URL || new URL(request.url).origin;
+  // Always return users to the host that started auth.
+  // This keeps localhost/127.0.0.1 dev working even when the app points at prod Supabase.
+  const origin = request.nextUrl.origin;
 
   const code = searchParams.get("code");           // OAuth (Google, Kakao)
   const token_hash = searchParams.get("token_hash"); // Magic link

--- a/app/profile/ProfileActivity.tsx
+++ b/app/profile/ProfileActivity.tsx
@@ -5,7 +5,7 @@ import Link from "next/link";
 import { Heart, MessageCircle, CornerDownRight } from "lucide-react";
 import { createClient } from "@/lib/supabase-browser";
 import { getCategoryLabel, getCategoryIcon } from "@/lib/post-categories";
-import { timeAgo } from "@/lib/utils";
+import { recencyLabel } from "@/lib/utils";
 import { cn } from "@/lib/utils";
 
 interface Props {
@@ -182,7 +182,7 @@ export function ProfileActivity({
                         </p>
                         <div className="flex items-center gap-3 text-xs text-gray-400">
                           <span>{getCategoryLabel(post.category)}</span>
-                          <span>{timeAgo(post.created_at)}</span>
+                          <span>{recencyLabel(post.created_at)}</span>
                           <span className="flex items-center gap-1">
                             <Heart className="w-3 h-3" /> {post.like_count}
                           </span>
@@ -232,7 +232,7 @@ export function ProfileActivity({
                         {comment.content}
                       </p>
                       <p className="text-xs text-gray-400">
-                        {timeAgo(comment.created_at)}
+                        {recencyLabel(comment.created_at)}
                       </p>
                     </Link>
                   </li>

--- a/components/ui/PostBadge.tsx
+++ b/components/ui/PostBadge.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { cn, timeAgo } from "@/lib/utils";
+import { cn, recencyLabel, timeAgo } from "@/lib/utils";
 import { getRegionLabel, getRegionIcon } from "@/lib/regions";
 import { getCategoryLabel, getCategoryIcon } from "@/lib/post-categories";
 import { getRegionColor, getCategoryColor } from "@/lib/colors";
@@ -8,11 +8,16 @@ import type { Post } from "@/types";
 
 interface Props {
   post: Post;
+  timeVariant?: "relative" | "bucket";
 }
 
-export function PostBadge({ post }: Props) {
+export function PostBadge({ post, timeVariant = "relative" }: Props) {
   const CatIcon = getCategoryIcon(post.category);
   const RegionIcon = post.region ? getRegionIcon(post.region) : null;
+  const timeLabel =
+    timeVariant === "bucket"
+      ? recencyLabel(post.created_at)
+      : timeAgo(post.created_at);
 
   return (
     <div className="flex items-center gap-1.5 ml-auto">
@@ -39,10 +44,9 @@ export function PostBadge({ post }: Props) {
         {getCategoryLabel(post.category)}
       </span>
       <span className="text-xs text-gray-400 flex-shrink-0">
-        {timeAgo(post.created_at)}
+        {timeLabel}
       </span>
     </div>
   );
 }
-
 

--- a/components/ui/PostCard.tsx
+++ b/components/ui/PostCard.tsx
@@ -59,7 +59,7 @@ export const PostCard = React.memo(function PostCard({
           </UserPopover>
 
           {/* Badge + menu row */}
-          <PostBadge post={post} />
+          <PostBadge post={post} timeVariant="bucket" />
           <PostMenu
             postId={post.id}
             authorId={post.author.id}

--- a/docs/auth-google-supabase.md
+++ b/docs/auth-google-supabase.md
@@ -72,15 +72,17 @@ NEXT_PUBLIC_APP_URL=http://localhost:3000
 ```
 
 > ⚠️ Make sure `supabase/.env` is gitignored. Check your root `.gitignore` includes `.env` — never commit OAuth secrets.
+>
+> `NEXT_PUBLIC_APP_URL` should be treated as your canonical/public site URL for metadata and links. Auth callbacks should return to the **current app origin** that started the flow.
 
 ### 4. `/app/auth/callback/route.ts`
 
 ```ts
 export async function GET(request: NextRequest) {
   const { searchParams } = new URL(request.url);
-  // ⚠️ Do NOT use `origin` from request.url in local dev
-  // request.url may come in as 127.0.0.1, but your app is on localhost
-  const origin = process.env.NEXT_PUBLIC_APP_URL || new URL(request.url).origin;
+  // Return to the same host that initiated auth.
+  // This keeps local dev working even when using prod Supabase credentials.
+  const origin = request.nextUrl.origin;
   const code = searchParams.get("code");
 
   if (code) {
@@ -122,7 +124,18 @@ Adding `localhost:3000/auth/callback` to Google Console does nothing. Google onl
 If your `redirectTo` URL (set in `signInWithOAuth`) isn't in Supabase's allow-list, Supabase silently falls back to `site_url` — skipping your callback route entirely. The user ends up on the home page **without a session established in the app**.
 
 ### ❌ `127.0.0.1` vs `localhost` mismatch
-`site_url = "http://127.0.0.1:3000"` and running Next.js on `localhost:3000` are different origins to the browser. Cookies set on one won't apply to the other. Always set `site_url` to match your actual dev URL (`localhost`), and use `NEXT_PUBLIC_APP_URL` to control redirects explicitly.
+`site_url = "http://127.0.0.1:3000"` and running Next.js on `localhost:3000` are different origins to the browser. Cookies set on one won't apply to the other. Always set `site_url` to match your actual dev URL, and make your auth callback return to the current request origin.
+
+### ❌ Local `HTTP ERROR 431` after login
+If local auth works in production but fails in `next dev` with `HTTP ERROR 431`, the request headers are usually too large because Supabase SSR auth cookies are chunked across multiple cookies. This is more likely when you're developing locally against a production Supabase project.
+
+Increase the local Node header limit for dev:
+
+```json
+"dev": "NODE_OPTIONS='--max-http-header-size=32768' next dev"
+```
+
+Apply the same override to any custom local dev scripts like `dev:local` or `dev:prod`.
 
 ### ❌ Using `.single()` for profile check
 `.single()` throws a PGRST116 error if no row is found. Use `.maybeSingle()` when a missing row is a valid, expected state (e.g., new user who hasn't set up a profile yet).
@@ -139,7 +152,7 @@ The Supabase CLI reads `env(VAR_NAME)` substitutions from **`supabase/.env`**, n
 
 - **Two separate tables**: `auth.users` (Supabase-managed) and `public.profiles` (your app data). Never store app-specific data in `auth.users`.
 - **App-managed profile creation**: Redirect new users to an onboarding page rather than auto-inserting a blank row via SQL trigger. This lets you collect required fields (nickname, handle) before they enter the app.
-- **`NEXT_PUBLIC_APP_URL`**: Always define this explicitly rather than inferring from `request.url` in server routes. In local dev, the request origin can differ from where your app is actually running.
+- **`NEXT_PUBLIC_APP_URL`**: Use this for canonical metadata, sitemap, and other public links. For auth callbacks, return to the current request origin so local dev, previews, and production each land back on the host that initiated auth.
 - **`skip_nonce_check = true` for local only**: Google's nonce verification doesn't work with Supabase local auth. This flag is safe locally but should not be set in production config.
 - **Wildcard redirect URLs**: Use `http://localhost:3000/**` in `additional_redirect_urls` rather than exact paths so any future callback routes work without config changes.
 

--- a/lib/constants.ts
+++ b/lib/constants.ts
@@ -47,3 +47,13 @@ export const TARGET_CITIES = [
   // ── 뉴욕 맨해튼 ────────────────────────────────
   { value: "Manhattan", label: "Manhattan, NY" },
 ] as const;
+
+export const RECENCY_LABEL_BUCKETS = [
+  { maxAgeDays: 1, label: "오늘" },
+  { maxAgeDays: 5, label: "최근" },
+  { maxAgeDays: 7, label: "이번주" },
+  { maxAgeDays: 14, label: "지난주" },
+  { maxAgeDays: 30, label: "이번달" },
+  { maxAgeDays: 60, label: "지난달" },
+  { maxAgeDays: Number.POSITIVE_INFINITY, label: "예전" },
+] as const;

--- a/lib/utils.ts
+++ b/lib/utils.ts
@@ -1,5 +1,6 @@
 import { clsx, type ClassValue } from "clsx";
 import { twMerge } from "tailwind-merge";
+import { RECENCY_LABEL_BUCKETS } from "@/lib/constants";
 
 export function cn(...inputs: ClassValue[]) {
   return twMerge(clsx(inputs));
@@ -11,6 +12,16 @@ export function timeAgo(date: string | Date): string {
   if (seconds < 3600) return `${Math.floor(seconds / 60)}분 전`;
   if (seconds < 86400) return `${Math.floor(seconds / 3600)}시간 전`;
   return `${Math.floor(seconds / 86400)}일 전`;
+}
+
+export function recencyLabel(date: string | Date): string {
+  const ageMs = Math.max(0, Date.now() - new Date(date).getTime());
+  const ageDays = ageMs / (1000 * 60 * 60 * 24);
+
+  return (
+    RECENCY_LABEL_BUCKETS.find((bucket) => ageDays <= bucket.maxAgeDays)?.label ??
+    RECENCY_LABEL_BUCKETS[RECENCY_LABEL_BUCKETS.length - 1].label
+  );
 }
 
 export function formatPhone(phone: string): string {

--- a/package.json
+++ b/package.json
@@ -3,9 +3,9 @@
   "version": "0.1.0",
   "private": true,
   "scripts": {
-    "dev": "next dev",
-    "dev:local": "env-cmd -f .env.local next dev",
-    "dev:prod": "env-cmd -f .env.prod next dev",
+    "dev": "NODE_OPTIONS='--max-http-header-size=32768' next dev",
+    "dev:local": "NODE_OPTIONS='--max-http-header-size=32768' env-cmd -f .env.local next dev",
+    "dev:prod": "NODE_OPTIONS='--max-http-header-size=32768' env-cmd -f .env.prod next dev",
     "build": "next build",
     "start": "next start",
     "test:e2e": "playwright test --reporter=line",


### PR DESCRIPTION
Return auth callbacks to the current request origin so local development stays on localhost even when using production Supabase. Also raise the local dev header limit to avoid HTTP 431 from large auth cookies and replace list time stamps with configurable recency buckets.