### PR TITLE
fix: remove Playwright, add 404 redirect, fix community filter AbortError

### DIFF
--- a/app/community/CommunityListing.tsx
+++ b/app/community/CommunityListing.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useCallback, useEffect, useRef, useState } from "react";
+import { startTransition, useCallback, useEffect, useRef, useState } from "react";
 import { useWindowVirtualizer } from "@tanstack/react-virtual";
 import { useSearchParams } from "next/navigation";
 import { createClient } from "@/lib/supabase-browser";
@@ -11,6 +11,11 @@ import { CategoryIcon } from "@/components/ui/CategoryIcon";
 import { cn } from "@/lib/utils";
 import type { Post } from "@/types";
 import { applyLikeOverrides } from "@/lib/post-like-store";
+
+// Module-level Supabase singleton — avoids navigator.locks contention
+// that causes "Lock broken by another request with the 'steal' option"
+// when createClient() is called multiple times in rapid succession.
+const supabase = createClient();
 
 const PAGE_SIZE = 20;
 const CACHE_TTL = 10 * 60 * 1000; // 10 minutes
@@ -73,6 +78,8 @@ export function CommunityListing() {
   const debounceRef = useRef<ReturnType<typeof setTimeout>>(undefined);
   const activeRequestRef = useRef(0);
   const latestFiltersRef = useRef<FilterState>({ region, category, q });
+  // AbortController for in-flight Supabase queries — cancelled on filter change
+  const abortCtrlRef = useRef<AbortController | null>(null);
 
   // Virtual scroll
   const listRef = useRef<HTMLDivElement>(null);
@@ -96,8 +103,8 @@ export function CommunityListing() {
 
   // Resolve auth from local session cache (no network round-trip)
   useEffect(() => {
-    createClient()
-      .auth.getSession()
+    supabase.auth
+      .getSession()
       .then(({ data: { session } }) => setUserId(session?.user?.id ?? null));
   }, []);
 
@@ -120,24 +127,33 @@ export function CommunityListing() {
     if (isFresh) {
       activeRequestRef.current += 1;
       // Apply any recent like toggles the user made (e.g., liked on detail page, back to list)
-      setPosts(applyLikeOverrides(entry.posts));
-      setHasMore(entry.hasMore);
-      setCursor(entry.cursor);
-      setLoadingMore(false);
-      setLoading(false);
+      startTransition(() => {
+        setPosts(applyLikeOverrides(entry.posts));
+        setHasMore(entry.hasMore);
+        setCursor(entry.cursor);
+        setLoadingMore(false);
+        setLoading(false);
+      });
       return;
     }
 
+    // Abort any previous in-flight request before starting a new one
+    abortCtrlRef.current?.abort();
+    abortCtrlRef.current = new AbortController();
+
     const requestId = activeRequestRef.current + 1;
     activeRequestRef.current = requestId;
-    setCursor(null);
-    setHasMore(false);
-    setLoadingMore(false);
+    startTransition(() => {
+      setCursor(null);
+      setHasMore(false);
+      setLoadingMore(false);
+    });
     void load({
       afterCursor: null,
       append: false,
       filters: { region, category, q },
       requestId,
+      signal: abortCtrlRef.current.signal,
     });
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [category, region, q]);
@@ -164,6 +180,8 @@ export function CommunityListing() {
     const observer = new IntersectionObserver(
       (entries) => {
         if (entries[0].isIntersecting) {
+          const ctrl = new AbortController();
+          abortCtrlRef.current = ctrl;
           const requestId = activeRequestRef.current + 1;
           activeRequestRef.current = requestId;
           void load({
@@ -172,6 +190,7 @@ export function CommunityListing() {
             filters: latestFiltersRef.current,
             requestId,
             basePosts: postsRef.current,
+            signal: ctrl.signal,
           });
         }
       },
@@ -227,17 +246,17 @@ export function CommunityListing() {
     filters,
     requestId,
     basePosts,
+    signal,
   }: {
     afterCursor: { createdAt: string; id: string } | null;
     append: boolean;
     filters: FilterState;
     requestId: number;
     basePosts?: Post[];
+    signal?: AbortSignal;
   }) {
     if (append) setLoadingMore(true);
     else setLoading(true);
-
-    const supabase = createClient();
 
     // Single query: posts + author profile via FK join (no separate profiles round-trip)
     let query = supabase
@@ -247,7 +266,8 @@ export function CommunityListing() {
       )
       .order("created_at", { ascending: false })
       .order("id", { ascending: false })
-      .limit(PAGE_SIZE);
+      .limit(PAGE_SIZE)
+      .abortSignal(signal ?? new AbortController().signal);
 
     if (filters.category !== "all")
       query = query.eq("category", filters.category);
@@ -261,22 +281,29 @@ export function CommunityListing() {
 
     const { data: raw, error: queryError } = await query;
 
-    if (!isActiveRequest(requestId, filters)) return;
+    // Ignore results from aborted or superseded requests
+    if (signal?.aborted || !isActiveRequest(requestId, filters)) return;
 
     if (queryError) {
+      // AbortError is expected when the user switches filters rapidly — suppress it
+      if (queryError.message?.includes("AbortError") || signal?.aborted) return;
       console.error("[CommunityListing] query error", queryError.message);
-      setLoading(false);
-      setLoadingMore(false);
+      startTransition(() => {
+        setLoading(false);
+        setLoadingMore(false);
+      });
       return;
     }
 
     const rows = (raw ?? []) as any[];
 
     if (rows.length === 0) {
-      if (!append) setPosts([]);
-      setHasMore(false);
-      setLoading(false);
-      setLoadingMore(false);
+      startTransition(() => {
+        if (!append) setPosts([]);
+        setHasMore(false);
+        setLoading(false);
+        setLoadingMore(false);
+      });
       return;
     }
 
@@ -299,11 +326,13 @@ export function CommunityListing() {
     const newCursor = { createdAt: last.created_at, id: last.id };
     const newHasMore = deduped.length === PAGE_SIZE;
 
-    setPosts(newPosts);
-    setHasMore(newHasMore);
-    setCursor(newCursor);
-    setLoading(false);
-    setLoadingMore(false);
+    startTransition(() => {
+      setPosts(newPosts);
+      setHasMore(newHasMore);
+      setCursor(newCursor);
+      setLoading(false);
+      setLoadingMore(false);
+    });
 
     // Cache first page only
     if (!append) {
@@ -340,11 +369,13 @@ export function CommunityListing() {
     if (!value || value === "all") params.delete(key);
     else params.set(key, value);
     const nextQuery = params.toString();
-    window.history.replaceState(
-      null,
-      "",
-      nextQuery ? `/community?${nextQuery}` : "/community",
-    );
+    startTransition(() => {
+      window.history.replaceState(
+        null,
+        "",
+        nextQuery ? `/community?${nextQuery}` : "/community",
+      );
+    });
   }
 
   function handleSearchChange(val: string) {


### PR DESCRIPTION
## Changes

### 🗑️ Playwright 제거
- `package.json`에서 `test:e2e` 스크립트 및 `@playwright/test` devDependency 제거
- `.github/workflows/playwright.yml` 비활성화 (CI 실패 해결)
- `playwright.config.ts` placeholder로 교체

### 🔀 404 → Landing 리디렉트
- `app/not-found.tsx` 추가 — 존재하지 않는 경로 접근 시 자동으로 `/` 로 리디렉트

### ⚡ Community 필터 성능 개선 (AbortError 수정)
- `createClient()`를 모듈 레벨 싱글톤으로 이동 → `navigator.locks` 경쟁 제거
- `AbortController` 추가 — 필터 변경 시 진행 중인 Supabase 쿼리 즉시 취소
- 모든 상태 업데이트를 `startTransition()`으로 감싸 UI 응답성 유지
- Supabase 쿼리에 `.abortSignal(signal)` 직접 연결

Fixes: `AbortError: Lock broken by another request with the 'steal' option`