### PR TITLE
fix(community): fix race conditions and request pileup on rapid filter switching

### DIFF
--- a/app/community/CommunityListing.tsx
+++ b/app/community/CommunityListing.tsx
@@ -73,6 +73,8 @@ export function CommunityListing() {
   const debounceRef = useRef<ReturnType<typeof setTimeout>>(undefined);
   const activeRequestRef = useRef(0);
   const latestFiltersRef = useRef<FilterState>({ region, category, q });
+  const overlayAbortRef = useRef<AbortController | null>(null);
+  const keyRef = useRef(key);
 
   // Virtual scroll
   const listRef = useRef<HTMLDivElement>(null);
@@ -103,6 +105,7 @@ export function CommunityListing() {
 
   useEffect(() => {
     latestFiltersRef.current = { region, category, q };
+    keyRef.current = makeCacheKey(region, category, q);
   }, [category, region, q]);
 
   useEffect(() => {
@@ -145,11 +148,21 @@ export function CommunityListing() {
   // Overlay like status once userId is known (non-blocking)
   useEffect(() => {
     if (!userId || posts.length === 0) return;
-    overlayLikes(posts, userId).then((updated) => {
+    // Cancel any in-flight overlayLikes request (prevents pileup on rapid filter switching)
+    overlayAbortRef.current?.abort();
+    const controller = new AbortController();
+    overlayAbortRef.current = controller;
+    const capturedKey = keyRef.current;
+
+    overlayLikes(posts, userId, controller.signal).then((updated) => {
+      // Discard if aborted or user has already switched to a different filter
+      if (controller.signal.aborted || keyRef.current !== capturedKey) return;
       setPosts(updated);
-      const entry = feedCache.get(key);
-      if (entry) feedCache.set(key, { ...entry, posts: updated });
+      const entry = feedCache.get(capturedKey);
+      if (entry) feedCache.set(capturedKey, { ...entry, posts: updated });
     });
+
+    return () => controller.abort();
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [userId, posts.length]); // re-run when posts load after userId resolves
 
@@ -192,20 +205,22 @@ export function CommunityListing() {
     );
   }
 
-  async function overlayLikes(list: Post[], uid: string): Promise<Post[]> {
+  async function overlayLikes(list: Post[], uid: string, signal?: AbortSignal): Promise<Post[]> {
     try {
       const res = await fetch("/api/posts/likes", {
         method: "POST",
         headers: { "Content-Type": "application/json" },
         credentials: "include",
         body: JSON.stringify({ post_ids: list.map((p) => p.id) }),
+        signal,
       });
       if (!res.ok) {
         console.error(
           "[CommunityListing] overlayLikes failed to fetch likes",
           res.status,
         );
-        return applyLikeOverrides(list.map((p) => ({ ...p, is_liked: false })));
+        // Preserve existing is_liked state on error rather than resetting to false
+        return applyLikeOverrides(list);
       }
       const body = await res.json().catch(() => ({}));
       const likedSet = new Set<string>(body.liked ?? []);
@@ -216,8 +231,13 @@ export function CommunityListing() {
       // Apply any recent like toggles the user made (survives page navigation)
       return applyLikeOverrides(withLikes);
     } catch (err) {
+      // AbortError is expected when switching filters rapidly — not a real error
+      if (err instanceof Error && err.name === "AbortError") {
+        return applyLikeOverrides(list);
+      }
       console.error("[CommunityListing] overlayLikes err", err);
-      return applyLikeOverrides(list.map((p) => ({ ...p, is_liked: false })));
+      // Preserve existing is_liked state on error rather than resetting to false
+      return applyLikeOverrides(list);
     }
   }
 
@@ -237,106 +257,121 @@ export function CommunityListing() {
     if (append) setLoadingMore(true);
     else setLoading(true);
 
-    const supabase = createClient();
+    try {
+      const supabase = createClient();
 
-    // Single query: posts + author profile via FK join (no separate profiles round-trip)
-    let query = supabase
-      .from("posts")
-      .select(
-        "id, title, content, category, region, user_id, like_count, comment_count, created_at, pinned, pinned_at, author:profiles!user_id(id, nickname, handle, location, avatar_url)",
-      )
-      .order("created_at", { ascending: false })
-      .order("id", { ascending: false })
-      .limit(PAGE_SIZE);
+      // Single query: posts + author profile via FK join (no separate profiles round-trip)
+      let query = supabase
+        .from("posts")
+        .select(
+          "id, title, content, category, region, user_id, like_count, comment_count, created_at, pinned, pinned_at, author:profiles!user_id(id, nickname, handle, location, avatar_url)",
+        )
+        .order("created_at", { ascending: false })
+        .order("id", { ascending: false })
+        .limit(PAGE_SIZE);
 
-    if (filters.category !== "all")
-      query = query.eq("category", filters.category);
-    if (filters.region !== "all") query = query.eq("region", filters.region);
-    if (filters.q.trim()) query = query.ilike("title", `%${filters.q.trim()}%`);
-    if (afterCursor) {
-      query = query.or(
-        `created_at.lt.${afterCursor.createdAt},and(created_at.eq.${afterCursor.createdAt},id.lt.${afterCursor.id})`,
-      );
-    }
+      if (filters.category !== "all")
+        query = query.eq("category", filters.category);
+      if (filters.region !== "all") query = query.eq("region", filters.region);
+      if (filters.q.trim()) query = query.ilike("title", `%${filters.q.trim()}%`);
+      if (afterCursor) {
+        query = query.or(
+          `created_at.lt.${afterCursor.createdAt},and(created_at.eq.${afterCursor.createdAt},id.lt.${afterCursor.id})`,
+        );
+      }
 
-    const { data: raw, error: queryError } = await query;
+      const { data: raw, error: queryError } = await query;
 
-    if (!isActiveRequest(requestId, filters)) return;
+      if (!isActiveRequest(requestId, filters)) return;
 
-    if (queryError) {
-      console.error("[CommunityListing] query error", queryError.message);
+      if (queryError) {
+        console.error("[CommunityListing] query error", queryError.message);
+        setLoading(false);
+        setLoadingMore(false);
+        return;
+      }
+
+      const rows = (raw ?? []) as any[];
+
+      if (rows.length === 0) {
+        if (!append) setPosts([]);
+        setHasMore(false);
+        setLoading(false);
+        setLoadingMore(false);
+        return;
+      }
+
+      // Dedupe by id
+      const seen = new Set<string>();
+      const deduped = rows.filter((p) => {
+        if (seen.has(p.id)) return false;
+        seen.add(p.id);
+        return true;
+      });
+
+      const list: Post[] = deduped.map((p) => ({
+        ...p,
+        author: p.author ?? { id: p.user_id, nickname: "알 수 없음" },
+        is_liked: false, // overlaid asynchronously after userId resolves
+      }));
+
+      const newPosts = append ? [...(basePosts ?? posts), ...list] : list;
+      const last = deduped[deduped.length - 1];
+      const newCursor = { createdAt: last.created_at, id: last.id };
+      const newHasMore = deduped.length === PAGE_SIZE;
+
+      setPosts(newPosts);
+      setHasMore(newHasMore);
+      setCursor(newCursor);
       setLoading(false);
       setLoadingMore(false);
-      return;
-    }
 
-    const rows = (raw ?? []) as any[];
+      // Cache first page only
+      if (!append) {
+        feedCache.set(makeCacheKey(filters.region, filters.category, filters.q), {
+          posts: list,
+          cursor: newCursor,
+          hasMore: newHasMore,
+          ts: Date.now(),
+        });
+      }
 
-    if (rows.length === 0) {
-      if (!append) setPosts([]);
-      setHasMore(false);
+      // Overlay likes if userId already resolved
+      if (userId) {
+        // Share the same abort ref so rapid filter switches cancel this request too.
+        // If posts.length changed, the overlayLikes useEffect will fire and take over.
+        overlayAbortRef.current?.abort();
+        const controller = new AbortController();
+        overlayAbortRef.current = controller;
+        overlayLikes(newPosts, userId, controller.signal).then((updated) => {
+          if (!isActiveRequest(requestId, filters) || controller.signal.aborted) return;
+          setPosts(updated);
+          if (!append) {
+            feedCache.set(
+              makeCacheKey(filters.region, filters.category, filters.q),
+              {
+                posts: updated,
+                cursor: newCursor,
+                hasMore: newHasMore,
+                ts: Date.now(),
+              },
+            );
+          }
+        });
+      }
+    } catch (err) {
+      // Guard: if a different request has already taken over, don't reset its loading state
+      if (!isActiveRequest(requestId, filters)) return;
+      console.error("[CommunityListing] load exception", err);
       setLoading(false);
       setLoadingMore(false);
-      return;
-    }
-
-    // Dedupe by id
-    const seen = new Set<string>();
-    const deduped = rows.filter((p) => {
-      if (seen.has(p.id)) return false;
-      seen.add(p.id);
-      return true;
-    });
-
-    const list: Post[] = deduped.map((p) => ({
-      ...p,
-      author: p.author ?? { id: p.user_id, nickname: "알 수 없음" },
-      is_liked: false, // overlaid asynchronously after userId resolves
-    }));
-
-    const newPosts = append ? [...(basePosts ?? posts), ...list] : list;
-    const last = deduped[deduped.length - 1];
-    const newCursor = { createdAt: last.created_at, id: last.id };
-    const newHasMore = deduped.length === PAGE_SIZE;
-
-    setPosts(newPosts);
-    setHasMore(newHasMore);
-    setCursor(newCursor);
-    setLoading(false);
-    setLoadingMore(false);
-
-    // Cache first page only
-    if (!append) {
-      feedCache.set(makeCacheKey(filters.region, filters.category, filters.q), {
-        posts: list,
-        cursor: newCursor,
-        hasMore: newHasMore,
-        ts: Date.now(),
-      });
-    }
-
-    // Overlay likes if userId already resolved
-    if (userId) {
-      overlayLikes(newPosts, userId).then((updated) => {
-        if (!isActiveRequest(requestId, filters)) return;
-        setPosts(updated);
-        if (!append) {
-          feedCache.set(
-            makeCacheKey(filters.region, filters.category, filters.q),
-            {
-              posts: updated,
-              cursor: newCursor,
-              hasMore: newHasMore,
-              ts: Date.now(),
-            },
-          );
-        }
-      });
     }
   }
 
   function setParam(key: string, value: string) {
-    const params = new URLSearchParams(searchParams.toString());
+    // Read from window.location.search (not searchParams React state) so rapid
+    // successive clicks don't overwrite each other with stale param snapshots.
+    const params = new URLSearchParams(window.location.search);
     if (!value || value === "all") params.delete(key);
     else params.set(key, value);
     const nextQuery = params.toString();


### PR DESCRIPTION
## 문제
커뮤니티 페이지에서 NYC Metro 선택 후 카테고리(생활↔커리어 등)를 빠르게 클릭하면 점점 느려지고 에러가 발생하는 현상

## 근본 원인 분석

### 1. Race condition — stale overlayLikes 결과가 현재 화면 덮어씌움
필터 전환 시 이전 `overlayLikes` fetch가 완료되면 현재 필터와 다른 데이터로 `setPosts` 호출

### 2. Request pileup — overlayLikes fetch 누적
`posts.length`가 바뀔 때마다 AbortController 없이 `/api/posts/likes` 요청이 쌓임

### 3. 중복 overlayLikes — `load()` 내부 요청도 취소 불가
useEffect의 abort가 `load()` 내부에서 시작한 overlayLikes는 취소하지 못함

### 4. Stale URL params — 빠른 클릭 시 파라미터 소실
`setParam`이 React의 `searchParams` (stale state) 를 읽어 region 선택 직후 category 클릭 시 region이 URL에서 사라짐

### 5. Infinite loading spinner — network 예외 시 stuck
`load()`에 try-catch 없어 Supabase/네트워크 예외 발생 시 `setLoading(false)`가 호출되지 않음

## 수정 내역

- **`overlayAbortRef` 추가** — 새 필터로 전환 시 이전 in-flight overlayLikes fetch 즉시 `abort()`
- **`keyRef` 추가** — `.then()` 콜백에서 filter key가 변경됐으면 `setPosts` 실행 차단
- **`load()`에 `overlayAbortRef` 공유** — `load()` 내부 overlayLikes도 동일 ref로 취소 가능
- **`setParam`을 `window.location.search`로 변경** — React state 대신 실제 현재 URL 읽음
- **`load()` 전체 try-catch 추가** — 예외 발생 시에도 반드시 loading 상태 리셋
- **AbortError 무음 처리** — 정상적인 취소를 에러로 기록하지 않음
- **에러 시 is_liked 보존** — 서버 에러 발생 시 기존 좋아요 상태 유지