### PR TITLE
fix(community): keep profile popover above posts

### DIFF
--- a/app/community/CommunityListing.tsx
+++ b/app/community/CommunityListing.tsx
@@ -68,6 +68,9 @@ export function CommunityListing() {
   const [loading, setLoading] = useState(!fresh);
   const [loadingMore, setLoadingMore] = useState(false);
   const [hasMore, setHasMore] = useState(fresh ? cached.hasMore : false);
+  const [activePopoverPostId, setActivePopoverPostId] = useState<string | null>(
+    null,
+  );
   const [cursor, setCursor] = useState<{
     createdAt: string;
     id: string;
@@ -611,12 +614,18 @@ export function CommunityListing() {
                     left: 0,
                     width: "100%",
                     paddingBottom: "16px",
+                    zIndex: activePopoverPostId === post.id ? 20 : 0,
                     transform: `translateY(${virtualItem.start - virtualizer.options.scrollMargin}px)`,
                   }}
                 >
                   <PostCard
                     post={post}
                     userId={userId}
+                    onPopoverOpenChange={(postId, open) => {
+                      setActivePopoverPostId((current) =>
+                        open ? postId : current === postId ? null : current,
+                      );
+                    }}
                     onPostEdited={handlePostEdited}
                     onPostDeleted={handlePostDeleted}
                   />

--- a/components/community/UserPopover.tsx
+++ b/components/community/UserPopover.tsx
@@ -24,9 +24,15 @@ interface Props {
   userId: string;
   nickname: string;
   children: React.ReactNode;
+  onOpenChange?: (open: boolean) => void;
 }
 
-export function UserPopover({ userId, nickname, children }: Props) {
+export function UserPopover({
+  userId,
+  nickname,
+  children,
+  onOpenChange,
+}: Props) {
   const [open, setOpen] = useState(false);
   const [profile, setProfile] = useState<PopoverState | null>(null);
   const [loading, setLoading] = useState(false);
@@ -127,6 +133,10 @@ export function UserPopover({ userId, nickname, children }: Props) {
     document.addEventListener("keydown", onKey);
     return () => document.removeEventListener("keydown", onKey);
   }, [open]);
+
+  useEffect(() => {
+    onOpenChange?.(open);
+  }, [onOpenChange, open]);
 
   useEffect(
     () => () => {

--- a/components/community/UserPopover.tsx
+++ b/components/community/UserPopover.tsx
@@ -36,10 +36,8 @@ export function UserPopover({
   const [open, setOpen] = useState(false);
   const [profile, setProfile] = useState<PopoverState | null>(null);
   const [loading, setLoading] = useState(false);
-  const [pos, setPos] = useState({ top: 0, left: 0 });
 
   const triggerRef = useRef<HTMLDivElement>(null);
-  const popoverRef = useRef<HTMLDivElement>(null);
   const openTimerRef = useRef<ReturnType<typeof setTimeout>>(undefined);
   const closeTimerRef = useRef<ReturnType<typeof setTimeout>>(undefined);
   const fetchedRef = useRef(false);
@@ -54,14 +52,6 @@ export function UserPopover({
   function scheduleOpen() {
     cancelClose();
     openTimerRef.current = setTimeout(() => {
-      if (!triggerRef.current) return;
-      const rect = triggerRef.current.getBoundingClientRect();
-      const popoverWidth = 260;
-      const left = Math.max(
-        8,
-        Math.min(rect.left, window.innerWidth - popoverWidth - 8),
-      );
-      setPos({ top: rect.bottom + 6, left });
       setOpen(true);
       if (!fetchedRef.current) {
         fetchedRef.current = true;
@@ -108,13 +98,6 @@ export function UserPopover({
     cancelOpen();
     cancelClose();
     if (!open) {
-      const rect = (e.currentTarget as HTMLElement).getBoundingClientRect();
-      const popoverWidth = 260;
-      const left = Math.max(
-        8,
-        Math.min(rect.left, window.innerWidth - popoverWidth - 8),
-      );
-      setPos({ top: rect.bottom + 6, left });
       setOpen(true);
       if (!fetchedRef.current) {
         fetchedRef.current = true;
@@ -153,73 +136,70 @@ export function UserPopover({
         onMouseEnter={scheduleOpen}
         onMouseLeave={scheduleClose}
         onClick={handleClick}
-        className="cursor-pointer select-none"
+        className="relative cursor-pointer select-none"
       >
         {children}
-      </div>
-
-      {open && (
-        <div
-          ref={popoverRef}
-          onMouseEnter={cancelClose}
-          onMouseLeave={scheduleClose}
-          className="fixed z-50 w-64 bg-white rounded-2xl shadow-xl border border-gray-100 p-4"
-          style={{ top: pos.top, left: pos.left }}
-        >
-          {loading || !profile ? (
-            <div className="space-y-3 animate-pulse">
-              <div className="flex items-center gap-3">
-                <div className="w-10 h-10 rounded-xl bg-gray-100 flex-shrink-0" />
-                <div className="flex-1 space-y-1.5">
-                  <div className="h-4 bg-gray-100 rounded w-3/4" />
-                  <div className="h-3 bg-gray-100 rounded w-1/2" />
+        {open && (
+          <div
+            onMouseEnter={cancelClose}
+            onMouseLeave={scheduleClose}
+            className="absolute left-0 top-full z-50 mt-2 w-64 rounded-2xl border border-gray-100 bg-white p-4 shadow-xl"
+          >
+            {loading || !profile ? (
+              <div className="space-y-3 animate-pulse">
+                <div className="flex items-center gap-3">
+                  <div className="h-10 w-10 flex-shrink-0 rounded-xl bg-gray-100" />
+                  <div className="flex-1 space-y-1.5">
+                    <div className="h-4 w-3/4 rounded bg-gray-100" />
+                    <div className="h-3 w-1/2 rounded bg-gray-100" />
+                  </div>
                 </div>
+                <div className="h-3 rounded bg-gray-100" />
+                <div className="h-3 w-4/5 rounded bg-gray-100" />
               </div>
-              <div className="h-3 bg-gray-100 rounded" />
-              <div className="h-3 bg-gray-100 rounded w-4/5" />
-            </div>
-          ) : (
-            <>
-              <ProfileCard
-                nickname={profile.nickname}
-                handle={profile.handle}
-                location={profile.location}
-                avatarUrl={profile.avatar_url}
-                size="md"
-                className="mb-3"
-              />
+            ) : (
+              <>
+                <ProfileCard
+                  nickname={profile.nickname}
+                  handle={profile.handle}
+                  location={profile.location}
+                  avatarUrl={profile.avatar_url}
+                  size="md"
+                  className="mb-3"
+                />
 
-              {profile.location && profile.locationLabel && (() => {
-                const LocIcon = getRegionIcon(profile.location!);
-                return (
-                  <p className="text-xs text-gray-600 border-t border-gray-50 pt-3 mb-3 flex items-center gap-1">
-                    <span className="text-gray-400">활동지역:</span>
-                    <LocIcon className="w-3 h-3" strokeWidth={2} />
-                    {profile.locationLabel}
+                {profile.location && profile.locationLabel && (() => {
+                  const LocIcon = getRegionIcon(profile.location!);
+                  return (
+                    <p className="mb-3 flex items-center gap-1 border-t border-gray-50 pt-3 text-xs text-gray-600">
+                      <span className="text-gray-400">활동지역:</span>
+                      <LocIcon className="h-3 w-3" strokeWidth={2} />
+                      {profile.locationLabel}
+                    </p>
+                  );
+                })()}
+
+                {profile.bio && (
+                  <p className="mb-3 border-t border-gray-50 pt-3 text-xs leading-relaxed text-gray-600">
+                    {profile.bio}
                   </p>
-                );
-              })()}
+                )}
 
-              {profile.bio && (
-                <p className="text-xs text-gray-600 leading-relaxed border-t border-gray-50 pt-3 mb-3">
-                  {profile.bio}
-                </p>
-              )}
-
-              <div className="flex items-center gap-3 text-[11px] text-gray-400 border-t border-gray-50 pt-3">
-                <span className="flex items-center gap-1">
-                  <Calendar className="w-3 h-3" />
-                  {new Date(profile.joined_at).toLocaleDateString("ko-KR", {
-                    year: "numeric",
-                    month: "short",
-                  })}
-                </span>
-                <span>게시글 {profile.post_count}개</span>
-              </div>
-            </>
-          )}
-        </div>
-      )}
+                <div className="flex items-center gap-3 border-t border-gray-50 pt-3 text-[11px] text-gray-400">
+                  <span className="flex items-center gap-1">
+                    <Calendar className="h-3 w-3" />
+                    {new Date(profile.joined_at).toLocaleDateString("ko-KR", {
+                      year: "numeric",
+                      month: "short",
+                    })}
+                  </span>
+                  <span>게시글 {profile.post_count}개</span>
+                </div>
+              </>
+            )}
+          </div>
+        )}
+      </div>
     </>
   );
 }

--- a/components/ui/PostCard.tsx
+++ b/components/ui/PostCard.tsx
@@ -15,6 +15,7 @@ import { ImageLightbox } from "@/components/ui/ImageLightbox";
 interface Props {
   post: Post;
   userId?: string | null;
+  onPopoverOpenChange?: (postId: string, open: boolean) => void;
   onPostEdited?: (
     postId: string,
     updated: {
@@ -31,6 +32,7 @@ interface Props {
 export const PostCard = React.memo(function PostCard({
   post,
   userId = null,
+  onPopoverOpenChange,
   onPostEdited,
   onPostDeleted,
 }: Props) {
@@ -49,7 +51,11 @@ export const PostCard = React.memo(function PostCard({
       <div className="bg-white border border-gray-100 rounded-2xl p-5 shadow-sm hover:border-[#FF5C5C]/30 transition-colors">
         {/* Author row */}
         <div className="flex items-center mb-3">
-          <UserPopover userId={post.author.id} nickname={post.author.nickname}>
+          <UserPopover
+            userId={post.author.id}
+            nickname={post.author.nickname}
+            onOpenChange={(open) => onPopoverOpenChange?.(post.id, open)}
+          >
             <ProfileCard
               nickname={post.author.nickname}
               handle={post.author.handle}


### PR DESCRIPTION
## Summary
- keep the active virtualized community row above neighboring posts while the user popover is open
- pass popover open state from the profile trigger through the post card to the listing
- preserve existing popover positioning behavior while fixing the stacking order bug

## Testing
- npm run build